### PR TITLE
Add errstr to parse error output

### DIFF
--- a/lib/XML/Feed.pm
+++ b/lib/XML/Feed.pm
@@ -48,7 +48,11 @@ sub parse {
     } else {
         $xml = $class->get_file($stream);
     }
-    return $class->error("Can't get feed XML content from $stream")
+    my $errstr = "Can't get feed XML content from $stream";
+    if ($class->errstr) {
+        $errstr .= ": " . $class->errstr;
+    }
+    return $class->error($errstr)
         unless $xml;
     my $format;
     if ($specified_format) {


### PR DESCRIPTION
This commit appends the errstr to the parse error output after the get calls if it exists.